### PR TITLE
Fix re-installing yumgroup on RHEL7

### DIFF
--- a/lib/puppet/provider/yumgroup/default.rb
+++ b/lib/puppet/provider/yumgroup/default.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:yumgroup).provide(:default) do
       end
 
       # turn on collecting when the 'Installed Groups:' is reached
-      collect_groups = true if line.chomp =~ /Installed Groups:/
+      collect_groups = true if line.chomp =~ /Installed Groups:/i
     end
     groups
   end

--- a/metadata.json
+++ b/metadata.json
@@ -5,5 +5,6 @@
   "summary": "Provides yumgroup type for RHEL systems",
   "license": "Apache 2.0",
   "source": "git://github.com/terrimonster/puppet-yumgroup.git",
-  "project_page": "https://github.com/terrimonster/puppet-yumgroup"
+  "project_page": "https://github.com/terrimonster/puppet-yumgroup",
+  "dependencies": []
 }


### PR DESCRIPTION
Oh RHEL7, 'Installed groups' starts with a lowercase g, so permit the regex to be case insensitive.

Include a 'dependencies' module metadata parameter so puppet likes us.
